### PR TITLE
Rate limiting using Flask-Limiter

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,8 @@ dictConfig(
     }
 )
 
+RATELIMIT_STORAGE_URI = os.environ.get("RATELIMIT_STORAGE_URI", "memory://")
+
 app = Flask(__name__)
 app.config.from_prefixed_env()
 log = app.logger
@@ -36,7 +38,7 @@ limiter = Limiter(
     get_remote_address,
     app=app,
     default_limits=["200 per day", "50 per hour"],
-    storage_uri="redis://redis:6379/",
+    storage_uri=RATELIMIT_STORAGE_URI,
 )
 
 # Use the DATABASE_URL environment variable if it exists, otherwise use the default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cython>=0.29.24
 Flask>=3.0.1
+Flask-Limiter[redis]>=3.8.0
 gunicorn>=23.0.0
 packaging==23
 psycopg[binary,pool]>=3.2.1


### PR DESCRIPTION
Changes applied are equal to the ones in https://github.com/bdist/bank-api-app/pull/2.

P.S: Flask-Limiter doesn't use any name-spacing in the keys inserted into redis. This means that 2 flask applications using the same redis instance, and that have routes that share name and rate limit rules, might have shared limits.